### PR TITLE
ADD: 任意のエラーメッセージを返すようコントローラにエラーハンドリングを追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3514,6 +3514,11 @@
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
     },
+    "fp-ts": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.11.8.tgz",
+      "integrity": "sha512-WQT6rP6Jt3TxMdQB3IKzvfZKLuldumntgumLhIUhvPrukTHdWNI4JgEHY04Bd0LIOR9IQRpB+7RuxgUU0Vhmcg=="
+    },
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -5624,6 +5629,14 @@
       "requires": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
+      }
+    },
+    "resultt": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resultt/-/resultt-2.0.0.tgz",
+      "integrity": "sha512-Q+WRlxX5A0+OeLrY4aBpODEHM2sCUSS5JL61vZ9yKRXN451BUtgIG50/3T8mzQ70feYmrLVn/j+XSo1ccxopYA==",
+      "requires": {
+        "fp-ts": "^2.11.5"
       }
     },
     "reusify": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "hbs": "^4.1.2",
     "mongodb": "^4.1.2",
     "reflect-metadata": "^0.1.13",
+    "resultt": "^2.0.0",
     "rimraf": "^3.0.2",
     "rxjs": "^7.2.0",
     "uuid": "^8.3.2"

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1,0 +1,1 @@
+console.log('jsのソースを表示');

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
 
   // 静的ファイル系
+  app.useStaticAssets(join(__dirname, '..', 'public'));
   app.setBaseViewsDir(join(__dirname, '..', 'views'));
   app.setViewEngine('hbs');
 

--- a/src/tasks/dto/find-all-tasks.interface.ts
+++ b/src/tasks/dto/find-all-tasks.interface.ts
@@ -2,6 +2,7 @@ import { TasksStatusJp } from '../type/value.object';
 
 export type FindAllTasks = {
   tasks: FindAllTasksElement[];
+  errors: string[];
 };
 
 export type FindAllTasksElement = {

--- a/src/tasks/tasks.controller.ts
+++ b/src/tasks/tasks.controller.ts
@@ -7,6 +7,9 @@ import {
 } from './dto/find-all-tasks.interface';
 import { SaveTasksUseCase } from './usecase/save.tasks.usecase';
 import { FindAllTasksUseCase } from './usecase/find.all.tasks.usecase';
+import { Resultt } from 'resultt';
+import { AppValidationException } from 'src/application/exception/app.validation.execption';
+import { ErrorConst } from 'src/application/error.consts';
 
 /**
  * タスクドメインコントローラクラス
@@ -27,10 +30,21 @@ export class TasksController {
   @Get()
   @Render('tasks')
   async findAll(): Promise<FindAllTasks> {
-    const tasks: Tasks[] = await this.findAllTasksUseCase.execute();
+    const errors: string[] = [];
+    let tasks: Tasks[] = [];
+    try {
+      tasks = await this.findAllTasksUseCase.execute();
+    } catch (e) {
+      if (e instanceof AppValidationException) {
+        errors.push(e.message);
+      } else {
+        errors.push(ErrorConst.E_SYSTEM_UNEXPECTED_ERROR.value);
+      }
+    }
 
     return {
       tasks: this.toFindAllTasksElement(tasks),
+      errors: errors,
     };
   }
 
@@ -42,10 +56,21 @@ export class TasksController {
   @Post()
   @Render('tasks')
   async capture(@Body() req: CaptureTasks): Promise<FindAllTasks> {
-    const tasks = await this.saveTasksUseCase.execute(req);
+    const errors: string[] = [];
+    let tasks: Tasks[] = [];
+    try {
+      tasks = await this.saveTasksUseCase.execute(req);
+    } catch (e) {
+      if (e instanceof AppValidationException) {
+        errors.push(e.message);
+      } else {
+        errors.push(ErrorConst.E_SYSTEM_UNEXPECTED_ERROR.value);
+      }
+    }
 
     return {
       tasks: this.toFindAllTasksElement(tasks),
+      errors: errors,
     };
   }
 

--- a/views/tasks.hbs
+++ b/views/tasks.hbs
@@ -17,6 +17,11 @@
                         {{/each}}
                     </ul>
                     {{/each}} 
+                    {{#each errors}}
+                    <ul>
+                        <li class="collection-item"> {{this}} </li>
+                    </ul>
+                    {{/each}}
                 </div>
                 <div class="col s6">
                     <form action="tasks" method="POST">
@@ -29,5 +34,6 @@
             </div>
         </div>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+        <script src="js/index.js"></script>
     </body>
 </html>


### PR DESCRIPTION
# 概要
タイトルの通り...

# 更新事項
- コントローラにエラーハンドリングを追加
- コントローラレスポンスに `errors` を追加
  - スローされた例外に応じてエラーメッセージを動的に選り分ける
- 設定したエラーメッセージをHTMLにバインドさせる